### PR TITLE
EPGStationの宛先のポート番号を変更

### DIFF
--- a/tunnel_config.tf
+++ b/tunnel_config.tf
@@ -5,7 +5,7 @@ resource "cloudflare_tunnel_config" "epgstation" {
   config {
     ingress_rule {
       hostname = "epgstation.hiroxto.net"
-      service  = "http://localhost:8888"
+      service  = "http://localhost:8080"
       origin_request {}
     }
     ingress_rule {


### PR DESCRIPTION
リバースプロキシの導入で宛先をNginxに変更するため，EPGStationの宛先のポート番号を変更。
