### PR TITLE
cloudflare_pages_project リソースから ID が取得できないので ID をハードコーディング

### DIFF
--- a/notification_policy.tf
+++ b/notification_policy.tf
@@ -66,13 +66,11 @@ resource "cloudflare_notification_policy" "pages_event_alert" {
     # 本番環境へのデプロイ失敗のみ受け取る
     environment = ["ENVIRONMENT_PRODUCTION"]
     event       = ["EVENT_DEPLOYMENT_FAILED"]
+    # NOTE: cloudflare_pages_project のリソースに ID 属性はあるが name 属性と同じ値が取得できるだけなのでハードコーディング
     project_id = [
-      cloudflare_pages_project.hiroxto_net.id,
-
-      # このリポジトリで管理していないプロジェクトはIDをハードコーディング
-      # TODO 他のPagesもこのリポジトリに取り込みたい
       "33a852bd-16a6-4d03-9251-2e90223ef8dc", # swarm-checkin-regulation-checker
       "55e413ae-b964-4671-bb0f-6a88fe146619", # hiroxto-utils-hiroxto-net
+      "c4aafd7f-f4ce-442d-a597-ddea67b8fa46", # hiroxto-net
     ]
   }
 }


### PR DESCRIPTION
cloudflare_pages_project リソースから ID が取得できなかったので，仕方なく ID をハードコーディングする