### PR TITLE
Tunnelのorigin_requestのオプションを設定

### DIFF
--- a/tunnel_config.tf
+++ b/tunnel_config.tf
@@ -5,7 +5,7 @@ resource "cloudflare_tunnel_config" "epgstation" {
   config {
     ingress_rule {
       hostname = "epgstation.hiroxto.net"
-      service  = "http://localhost:8080"
+      service  = "http://127.0.0.1:8080"
       origin_request {
         connect_timeout = "1m0s"
         tls_timeout     = "1m0s"


### PR DESCRIPTION
Gateway time-outが頻発するため，Tunnelのorigin_requestのオプションを設定して様子見する