### PR TITLE
EPGStation 専用ポリシーを削除して再利用可能なポリシーを使うように変更

### DIFF
--- a/access_application.tf
+++ b/access_application.tf
@@ -7,6 +7,9 @@ resource "cloudflare_access_application" "epgstation" {
   allowed_idps = [
     cloudflare_access_identity_provider.google.id,
   ]
+  policies = [
+    cloudflare_access_policy.admin.id
+  ]
   auto_redirect_to_identity  = false
   session_duration           = "168h" # 1 weeks
   same_site_cookie_attribute = "lax"

--- a/access_group.tf
+++ b/access_group.tf
@@ -1,12 +1,3 @@
-resource "cloudflare_access_group" "dtv_admin" {
-  account_id = cloudflare_account.main.id
-  name       = "DTV Admin"
-
-  include {
-    email = [var.admin_gmail_address]
-  }
-}
-
 resource "cloudflare_access_group" "admin" {
   account_id = cloudflare_account.main.id
   name       = "Infra Admin"

--- a/access_policy.tf
+++ b/access_policy.tf
@@ -1,15 +1,3 @@
-resource "cloudflare_access_policy" "epgstation" {
-  application_id = cloudflare_access_application.epgstation.id
-  account_id     = cloudflare_account.main.id
-  name           = "EPGStation"
-  decision       = "allow"
-  precedence     = 1
-
-  include {
-    group = [cloudflare_access_group.dtv_admin.id]
-  }
-}
-
 resource "cloudflare_access_policy" "admin" {
   account_id = cloudflare_account.main.id
   name       = "Allow infra admin"


### PR DESCRIPTION
EPGStation 専用ポリシーを削除して再利用可能なポリシーを使うように変更

`cloudflare_access_policy`に`application_id`を設定するのが非推奨になったので，`cloudflare_access_application`でポリシーを紐付けるように変更