### PR TITLE
Cloudflare Pages 関連のリソースをサブモジュールに移動

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,11 @@ module "notification" {
   target_email          = var.admin_gmail_address
 }
 
+module "pages" {
+  source                = "./pages"
+  cloudflare_account_id = cloudflare_account.main.id
+}
+
 module "zero_trust" {
   source                     = "./zero_trust"
   cloudflare_account_id      = cloudflare_account.main.id

--- a/pages/pages_project.tf
+++ b/pages/pages_project.tf
@@ -1,5 +1,5 @@
 resource "cloudflare_pages_project" "hiroxto_net" {
-  account_id        = cloudflare_account.main.id
+  account_id        = var.cloudflare_account_id
   name              = "hiroxto-net"
   production_branch = "master"
 
@@ -49,7 +49,7 @@ resource "cloudflare_pages_project" "hiroxto_net" {
 }
 
 resource "cloudflare_pages_project" "train_photo_blog" {
-  account_id        = cloudflare_account.main.id
+  account_id        = var.cloudflare_account_id
   name              = "hiroxto-train-photo-blog"
   production_branch = "master"
 

--- a/pages/terraform.tf
+++ b/pages/terraform.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/pages/variables.tf
+++ b/pages/variables.tf
@@ -1,0 +1,4 @@
+variable "cloudflare_account_id" {
+  type        = string
+  description = "Cloudflare の Account ID"
+}


### PR DESCRIPTION
Cloudflare Pages 関連のリソースをサブモジュールに移動。
将来的に `cloudflare_pages_domain` などもインポートしたときにルートを綺麗にするため先に移動しておく。

state mv で移動したので plan の差分は発生しない。

<details><summary>移行に使ったコマンド</summary>

```sh
tf state mv -state=local.tfstate cloudflare_pages_project.hiroxto_net module.pages.cloudflare_pages_project.hiroxto_net
tf state mv -state=local.tfstate cloudflare_pages_project.train_photo_blog module.pages.cloudflare_pages_project.train_photo_blog
```

</details> 