### PR TITLE
New Relic 用のアクセスポリシーを作成して EPGStation に適用

### DIFF
--- a/zero_trust/access_application.tf
+++ b/zero_trust/access_application.tf
@@ -8,7 +8,8 @@ resource "cloudflare_access_application" "epgstation" {
     cloudflare_access_identity_provider.google.id,
   ]
   policies = [
-    cloudflare_access_policy.admin.id
+    cloudflare_access_policy.admin.id,
+    cloudflare_access_policy.new_relic.id
   ]
   auto_redirect_to_identity  = false
   session_duration           = "168h" # 1 weeks

--- a/zero_trust/access_policy.tf
+++ b/zero_trust/access_policy.tf
@@ -9,3 +9,15 @@ resource "cloudflare_access_policy" "admin" {
     ]
   }
 }
+
+resource "cloudflare_access_policy" "new_relic" {
+  account_id = var.cloudflare_account_id
+  name       = "Allow New Relic"
+  decision   = "allow"
+
+  include {
+    service_token = [
+      cloudflare_access_service_token.new_relic.id
+    ]
+  }
+}


### PR DESCRIPTION
New Relic 用のアクセスポリシーを作成して EPGStation に適用。
これ適用しないと 302 でリダイレクトされるっぽい。