### PR TITLE
New RelicのSynthetics Monitorを一時的に無効化したのでアクセスポリシーからも一時的に外す

### DIFF
--- a/zero_trust/access_application.tf
+++ b/zero_trust/access_application.tf
@@ -9,7 +9,7 @@ resource "cloudflare_access_application" "epgstation" {
   ]
   policies = [
     cloudflare_access_policy.admin.id,
-    cloudflare_access_policy.new_relic.id
+    # cloudflare_access_policy.new_relic.id
   ]
   auto_redirect_to_identity  = false
   session_duration           = "168h" # 1 weeks


### PR DESCRIPTION
#103 でNew RelicのSynthetics Monitorを一時的に無効化したのでアクセスポリシーからも一時的に外す