### PR TITLE
Synthetics Monitorのリソースを復活

### DIFF
--- a/observe/nrql_alert_condition.tf
+++ b/observe/nrql_alert_condition.tf
@@ -90,23 +90,23 @@ resource "newrelic_nrql_alert_condition" "low_application_throughput" {
 #
 # DTV Alerts
 #
-# resource "newrelic_nrql_alert_condition" "epgstation_health_check" {
-#   name               = "EPGStation health check"
-#   policy_id          = newrelic_alert_policy.dtv_alerts.id
-#   enabled            = true
-#   type               = "static"
-#   aggregation_window = 300
-#   aggregation_method = "event_flow"
-#   aggregation_delay  = 0
-#
-#   nrql {
-#     query = "SELECT latest(if(result = 'FAILED', 1, 0)) FROM SyntheticCheck WHERE entityGuid = '${newrelic_synthetics_monitor.epgstation.id}' FACET entityGuid, monitorName"
-#   }
-#
-#   critical {
-#     operator              = "above_or_equals"
-#     threshold             = 1.0
-#     threshold_duration    = 300
-#     threshold_occurrences = "all"
-#   }
-# }
+resource "newrelic_nrql_alert_condition" "epgstation_health_check" {
+  name               = "EPGStation health check"
+  policy_id          = newrelic_alert_policy.dtv_alerts.id
+  enabled            = false
+  type               = "static"
+  aggregation_window = 300
+  aggregation_method = "event_flow"
+  aggregation_delay  = 0
+
+  nrql {
+    query = "SELECT latest(if(result = 'FAILED', 1, 0)) FROM SyntheticCheck WHERE entityGuid = '${newrelic_synthetics_monitor.epgstation.id}' FACET entityGuid, monitorName"
+  }
+
+  critical {
+    operator              = "above_or_equals"
+    threshold             = 1.0
+    threshold_duration    = 300
+    threshold_occurrences = "all"
+  }
+}

--- a/observe/synthetics_monitor.tf
+++ b/observe/synthetics_monitor.tf
@@ -1,25 +1,25 @@
-# resource "newrelic_synthetics_monitor" "epgstation" {
-#   status           = "ENABLED"
-#   name             = "EPGStation"
-#   period           = "EVERY_5_MINUTES"
-#   uri              = var.epgstation_uri
-#   type             = "SIMPLE"
-#   locations_public = ["AWS_AP_NORTHEAST_1"]
-#
-#   verify_ssl                = true
-#   treat_redirect_as_failure = true
-#   bypass_head_request       = true
-#
-#   custom_header {
-#     name  = "Cache-Control"
-#     value = "no-cache"
-#   }
-#   custom_header {
-#     name  = "CF-Access-Client-Id"
-#     value = var.cfa_client_id
-#   }
-#   custom_header {
-#     name  = "CF-Access-Client-Secret"
-#     value = var.cfa_client_secret
-#   }
-# }
+resource "newrelic_synthetics_monitor" "epgstation" {
+  status           = "DISABLED"
+  name             = "EPGStation"
+  period           = "EVERY_5_MINUTES"
+  uri              = var.epgstation_uri
+  type             = "SIMPLE"
+  locations_public = ["AWS_AP_NORTHEAST_1"]
+
+  verify_ssl                = true
+  treat_redirect_as_failure = true
+  bypass_head_request       = true
+
+  custom_header {
+    name  = "Cache-Control"
+    value = "no-cache"
+  }
+  custom_header {
+    name  = "CF-Access-Client-Id"
+    value = var.cfa_client_id
+  }
+  custom_header {
+    name  = "CF-Access-Client-Secret"
+    value = var.cfa_client_secret
+  }
+}


### PR DESCRIPTION
Synthetics Monitorのリソースを復活させた
リソースを消さずとも無効化状態にしておけば良いだけだった。

有効化する時はステータスの切り替えと https://github.com/hiroxto/infrastructure/pull/105 を打ち消してアクセスポリシーを適用させる必要がある。