### PR TITLE
cloudflare_recordのvalueが非推奨になりcontentに変更されたので修正

### DIFF
--- a/hiroxto_net/record.tf
+++ b/hiroxto_net/record.tf
@@ -5,7 +5,7 @@ resource "cloudflare_record" "cname_root" {
   zone_id = data.cloudflare_zone.main.id
   name    = data.cloudflare_zone.main.name
   type    = "CNAME"
-  value   = var.records.cname_root
+  content = var.records.cname_root
   proxied = true
 }
 
@@ -13,7 +13,7 @@ resource "cloudflare_record" "cname_www" {
   zone_id = data.cloudflare_zone.main.id
   name    = "www"
   type    = "CNAME"
-  value   = var.records.cname_www
+  content = var.records.cname_www
   proxied = true
 }
 
@@ -21,7 +21,7 @@ resource "cloudflare_record" "cname_swarm_checkin_regulation_checker" {
   zone_id = data.cloudflare_zone.main.id
   name    = "swarm-checkin-regulation-checker"
   type    = "CNAME"
-  value   = "swarm-checkin-regulation-checker.pages.dev"
+  content = "swarm-checkin-regulation-checker.pages.dev"
   proxied = true
 }
 
@@ -29,7 +29,7 @@ resource "cloudflare_record" "cname_train_photo_blog" {
   zone_id = data.cloudflare_zone.main.id
   type    = "CNAME"
   name    = "train-photo-blog"
-  value   = var.records.cname_train_photo_blog
+  content = var.records.cname_train_photo_blog
   proxied = true
 }
 
@@ -37,7 +37,7 @@ resource "cloudflare_record" "cname_utils" {
   zone_id = data.cloudflare_zone.main.id
   name    = "utils"
   type    = "CNAME"
-  value   = "hiroxto-utils-hiroxto-net.pages.dev"
+  content = "hiroxto-utils-hiroxto-net.pages.dev"
   proxied = true
 }
 
@@ -45,7 +45,7 @@ resource "cloudflare_record" "cname_epgstation" {
   zone_id = data.cloudflare_zone.main.id
   name    = "epgstation"
   type    = "CNAME"
-  value   = var.records.cname_epgstation
+  content = var.records.cname_epgstation
   proxied = true
 }
 
@@ -53,7 +53,7 @@ resource "cloudflare_record" "cname_eq12_01_ssh" {
   zone_id = data.cloudflare_zone.main.id
   name    = "eq12-01-ssh"
   type    = "CNAME"
-  value   = var.records.cname_eq12_01_ssh
+  content = var.records.cname_eq12_01_ssh
   proxied = true
 }
 
@@ -64,7 +64,7 @@ resource "cloudflare_record" "mx_1" {
   zone_id  = data.cloudflare_zone.main.id
   name     = data.cloudflare_zone.main.name
   type     = "MX"
-  value    = "route1.mx.cloudflare.net"
+  content  = "route1.mx.cloudflare.net"
   priority = 57
 }
 
@@ -72,7 +72,7 @@ resource "cloudflare_record" "mx_2" {
   zone_id  = data.cloudflare_zone.main.id
   name     = data.cloudflare_zone.main.name
   type     = "MX"
-  value    = "route2.mx.cloudflare.net"
+  content  = "route2.mx.cloudflare.net"
   priority = 73
 }
 
@@ -80,7 +80,7 @@ resource "cloudflare_record" "mx_3" {
   zone_id  = data.cloudflare_zone.main.id
   name     = data.cloudflare_zone.main.name
   type     = "MX"
-  value    = "route3.mx.cloudflare.net"
+  content  = "route3.mx.cloudflare.net"
   priority = 29
 }
 
@@ -91,21 +91,21 @@ resource "cloudflare_record" "txt_spf" {
   zone_id = data.cloudflare_zone.main.id
   name    = data.cloudflare_zone.main.name
   type    = "TXT"
-  value   = "v=spf1 include:_spf.mx.cloudflare.net include:_spf.google.com ~all"
+  content = "v=spf1 include:_spf.mx.cloudflare.net include:_spf.google.com ~all"
 }
 
 resource "cloudflare_record" "txt_dmarc" {
   zone_id = data.cloudflare_zone.main.id
   name    = "_dmarc"
   type    = "TXT"
-  value   = "v=DMARC1;  p=none; rua=mailto:97f14f78b6474427b3c6f73b9464f836@dmarc-reports.cloudflare.net"
+  content = "v=DMARC1;  p=none; rua=mailto:97f14f78b6474427b3c6f73b9464f836@dmarc-reports.cloudflare.net"
 }
 
 resource "cloudflare_record" "txt_atproto" {
   zone_id = data.cloudflare_zone.main.id
   name    = "_atproto"
   type    = "TXT"
-  value   = "did=did:plc:ky336ximtcas2d34kfg3sosh"
+  content = "did=did:plc:ky336ximtcas2d34kfg3sosh"
   comment = "For Bluesky handle"
 }
 
@@ -113,7 +113,7 @@ resource "cloudflare_record" "txt_discord_verify" {
   zone_id = data.cloudflare_zone.main.id
   name    = "_discord.www.hiroxto.net"
   type    = "TXT"
-  value   = "dh=f2f8abd2008da9da8d2532f632b4af7f2843f428"
+  content = "dh=f2f8abd2008da9da8d2532f632b4af7f2843f428"
   comment = "For Discord verify"
 }
 
@@ -121,7 +121,7 @@ resource "cloudflare_record" "txt_google_site_verify" {
   zone_id = data.cloudflare_zone.main.id
   name    = data.cloudflare_zone.main.name
   type    = "TXT"
-  value   = "google-site-verification=OWvIVzu3yp2cgeSe6ubYDCEyBk0BchElGwtbEXLzcdw"
+  content = "google-site-verification=OWvIVzu3yp2cgeSe6ubYDCEyBk0BchElGwtbEXLzcdw"
   comment = "For Google Site verify"
 }
 
@@ -129,6 +129,6 @@ resource "cloudflare_record" "txt_keybase_verify" {
   zone_id = data.cloudflare_zone.main.id
   name    = data.cloudflare_zone.main.name
   type    = "TXT"
-  value   = "keybase-site-verification=awgxLY0PHHrVJQKhhDri44iFtoaXYmAk5MPD9L3PNqs"
+  content = "keybase-site-verification=awgxLY0PHHrVJQKhhDri44iFtoaXYmAk5MPD9L3PNqs"
   comment = "For Keybase verify"
 }


### PR DESCRIPTION
#129 で cloudflare_record の value が非推奨になり content に変更されたので修正

Check
- [x] plan で差分なし
- [x] `Warning: Argument is deprecated`が消えている