### PR TITLE
Cloudflare Zero Trustリソースのdeprecated対応 その1

### DIFF
--- a/zero_trust/access_application.tf
+++ b/zero_trust/access_application.tf
@@ -8,8 +8,8 @@ resource "cloudflare_access_application" "epgstation" {
     cloudflare_access_identity_provider.google.id,
   ]
   policies = [
-    cloudflare_access_policy.admin.id,
-    # cloudflare_access_policy.new_relic.id
+    cloudflare_zero_trust_access_policy.admin.id,
+    # cloudflare_zero_trust_access_policy.new_relic.id
   ]
   auto_redirect_to_identity  = false
   session_duration           = "168h" # 1 weeks
@@ -30,6 +30,6 @@ resource "cloudflare_access_application" "eq12_01_ssh" {
     cloudflare_access_identity_provider.google.id,
   ]
   policies = [
-    cloudflare_access_policy.admin.id
+    cloudflare_zero_trust_access_policy.admin.id
   ]
 }

--- a/zero_trust/access_application.tf
+++ b/zero_trust/access_application.tf
@@ -1,4 +1,4 @@
-resource "cloudflare_access_application" "epgstation" {
+resource "cloudflare_zero_trust_access_application" "epgstation" {
   account_id           = var.cloudflare_account_id
   name                 = "EPGStation"
   domain               = var.app_epgstation_domain
@@ -20,7 +20,7 @@ resource "cloudflare_access_application" "epgstation" {
   options_preflight_bypass   = true
 }
 
-resource "cloudflare_access_application" "eq12_01_ssh" {
+resource "cloudflare_zero_trust_access_application" "eq12_01_ssh" {
   account_id           = var.cloudflare_account_id
   name                 = "eq12-01-ssh"
   domain               = var.app_eq12_01_ssh_domain

--- a/zero_trust/access_group.tf
+++ b/zero_trust/access_group.tf
@@ -1,4 +1,4 @@
-resource "cloudflare_access_group" "admin" {
+resource "cloudflare_zero_trust_access_group" "admin" {
   account_id = var.cloudflare_account_id
   name       = "Infra Admin"
 

--- a/zero_trust/access_organization.tf
+++ b/zero_trust/access_organization.tf
@@ -1,7 +1,8 @@
-resource "cloudflare_access_organization" "main" {
+resource "cloudflare_zero_trust_access_organization" "main" {
   auth_domain = "hiroxto.cloudflareaccess.com"
   account_id  = var.cloudflare_account_id
   name        = "hiroxto.cloudflareaccess.com"
 
+  custom_pages {}
   login_design {}
 }

--- a/zero_trust/access_policy.tf
+++ b/zero_trust/access_policy.tf
@@ -17,7 +17,7 @@ resource "cloudflare_access_policy" "new_relic" {
 
   include {
     service_token = [
-      cloudflare_access_service_token.new_relic.id
+      cloudflare_zero_trust_access_service_token.new_relic.id
     ]
   }
 }

--- a/zero_trust/access_policy.tf
+++ b/zero_trust/access_policy.tf
@@ -5,7 +5,7 @@ resource "cloudflare_access_policy" "admin" {
 
   include {
     group = [
-      cloudflare_access_group.admin.id
+      cloudflare_zero_trust_access_group.admin.id
     ]
   }
 }

--- a/zero_trust/access_policy.tf
+++ b/zero_trust/access_policy.tf
@@ -1,4 +1,4 @@
-resource "cloudflare_access_policy" "admin" {
+resource "cloudflare_zero_trust_access_policy" "admin" {
   account_id = var.cloudflare_account_id
   name       = "Allow infra admin"
   decision   = "allow"
@@ -10,7 +10,7 @@ resource "cloudflare_access_policy" "admin" {
   }
 }
 
-resource "cloudflare_access_policy" "new_relic" {
+resource "cloudflare_zero_trust_access_policy" "new_relic" {
   account_id = var.cloudflare_account_id
   name       = "Bypass New Relic"
   decision   = "bypass"

--- a/zero_trust/access_service_token.tf
+++ b/zero_trust/access_service_token.tf
@@ -1,4 +1,4 @@
-resource "cloudflare_access_service_token" "new_relic" {
+resource "cloudflare_zero_trust_access_service_token" "new_relic" {
   account_id = var.cloudflare_account_id
   name       = "New Relic"
   duration   = "forever"

--- a/zero_trust/outputs.tf
+++ b/zero_trust/outputs.tf
@@ -31,11 +31,11 @@ output "tunnel_epgstation_cname" {
 # Access Service Tokens
 #
 output "cfa_token_new_relic_client_id" {
-  value     = cloudflare_access_service_token.new_relic.client_id
+  value     = cloudflare_zero_trust_access_service_token.new_relic.client_id
   sensitive = true
 }
 
 output "cfa_token_new_relic_client_secret" {
-  value     = cloudflare_access_service_token.new_relic.client_secret
+  value     = cloudflare_zero_trust_access_service_token.new_relic.client_secret
   sensitive = true
 }

--- a/zero_trust/tunnel_config.tf
+++ b/zero_trust/tunnel_config.tf
@@ -4,7 +4,7 @@ resource "cloudflare_tunnel_config" "eq12_01" {
 
   config {
     ingress_rule {
-      hostname = cloudflare_access_application.epgstation.domain
+      hostname = cloudflare_zero_trust_access_application.epgstation.domain
       service  = "http://127.0.0.1:8080"
       origin_request {
         connect_timeout = "1m0s"
@@ -13,7 +13,7 @@ resource "cloudflare_tunnel_config" "eq12_01" {
       }
     }
     ingress_rule {
-      hostname = cloudflare_access_application.eq12_01_ssh.domain
+      hostname = cloudflare_zero_trust_access_application.eq12_01_ssh.domain
       service  = "ssh://127.0.0.1:9922"
     }
     ingress_rule {


### PR DESCRIPTION
#136 のマージでいくつかのCloudflare Zero Trustリソースがdeprecatedになったので解消する。
簡単に移行できたリソースだけ先にマージする。

移行対象
- cloudflare_access_organization → cloudflare_zero_trust_access_organization
- cloudflare_access_service_token → cloudflare_zero_trust_access_service_token
- cloudflare_access_group → cloudflare_zero_trust_access_group
- cloudflare_access_policy → cloudflare_zero_trust_access_policy
- cloudflare_access_application → cloudflare_zero_trust_access_application

Check
- [x] 上記リソースのWarning: Deprecated Resourceが消えている
- [x] planに差分無し