### PR TITLE
raspi-4b-01のSSH接続を復活

### DIFF
--- a/hiroxto_net/outputs.tf
+++ b/hiroxto_net/outputs.tf
@@ -4,8 +4,9 @@ output "zone_id" {
 
 output "records" {
   value = {
-    cname_epgstation_hostname     = cloudflare_record.cname_epgstation.hostname
-    cname_eq12_01_ssh_hostname    = cloudflare_record.cname_eq12_01_ssh.hostname
-    cname_home_assistant_hostname = cloudflare_record.cname_home_assistant.hostname
+    cname_epgstation_hostname      = cloudflare_record.cname_epgstation.hostname
+    cname_eq12_01_ssh_hostname     = cloudflare_record.cname_eq12_01_ssh.hostname
+    cname_raspi_4b_01_ssh_hostname = cloudflare_record.cname_raspi_4b_01_ssh.hostname
+    cname_home_assistant_hostname  = cloudflare_record.cname_home_assistant.hostname
   }
 }

--- a/hiroxto_net/record.tf
+++ b/hiroxto_net/record.tf
@@ -57,6 +57,14 @@ resource "cloudflare_record" "cname_eq12_01_ssh" {
   proxied = true
 }
 
+resource "cloudflare_record" "cname_raspi_4b_01_ssh" {
+  zone_id = data.cloudflare_zone.main.id
+  name    = "raspi-4b-01-ssh"
+  type    = "CNAME"
+  content = var.records.cname_raspi_4b_01_ssh
+  proxied = true
+}
+
 resource "cloudflare_record" "cname_home_assistant" {
   zone_id = data.cloudflare_zone.main.id
   name    = "home-assistant"

--- a/hiroxto_net/variables.tf
+++ b/hiroxto_net/variables.tf
@@ -24,6 +24,7 @@ variable "records" {
     cname_train_photo_blog = string
     cname_epgstation       = string
     cname_eq12_01_ssh      = string
+    cname_raspi_4b_01_ssh  = string
     cname_home_assistant   = string
   })
   description = "DNSレコードの設定"

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ module "hiroxto_net" {
     cname_train_photo_blog = module.pages.train_photo_blog_subdomain
     cname_epgstation       = module.zero_trust.tunnel_epgstation_cname
     cname_eq12_01_ssh      = module.zero_trust.tunnel_eq12_01_cname
+    cname_raspi_4b_01_ssh  = module.zero_trust.tunnel_raspi_4b_01_cname
     cname_home_assistant   = module.zero_trust.tunnel_eq12_01_cname
   }
 }
@@ -50,6 +51,7 @@ module "zero_trust" {
   idp_google_client_secret     = var.idp_google_client_secret
   app_epgstation_domain        = module.hiroxto_net.records.cname_epgstation_hostname
   app_eq12_01_ssh_domain       = module.hiroxto_net.records.cname_eq12_01_ssh_hostname
+  app_raspi_4b_01_ssh_domain   = module.hiroxto_net.records.cname_raspi_4b_01_ssh_hostname
   tunnel_home_assistant_domain = module.hiroxto_net.records.cname_home_assistant_hostname
 }
 

--- a/zero_trust/access_application.tf
+++ b/zero_trust/access_application.tf
@@ -33,3 +33,20 @@ resource "cloudflare_zero_trust_access_application" "eq12_01_ssh" {
     cloudflare_zero_trust_access_policy.admin.id
   ]
 }
+
+#
+# raspi-4b-01
+#
+resource "cloudflare_zero_trust_access_application" "raspi_4b_01_ssh" {
+  account_id           = var.cloudflare_account_id
+  name                 = "raspi-4b-01-ssh"
+  domain               = var.app_raspi_4b_01_ssh_domain
+  type                 = "ssh"
+  app_launcher_visible = false
+  allowed_idps = [
+    cloudflare_access_identity_provider.google.id,
+  ]
+  policies = [
+    cloudflare_zero_trust_access_policy.admin.id
+  ]
+}

--- a/zero_trust/outputs.tf
+++ b/zero_trust/outputs.tf
@@ -19,6 +19,27 @@ output "tunnel_eq12_01_cname" {
   value = cloudflare_tunnel.eq12_01.cname
 }
 
+#
+# raspi-4b-01
+#
+output "tunnel_raspi_4b_01_id" {
+  value = cloudflare_zero_trust_tunnel_cloudflared.raspi_4b_01.id
+}
+
+output "tunnel_raspi_4b_01_secret" {
+  value     = cloudflare_zero_trust_tunnel_cloudflared.raspi_4b_01.secret
+  sensitive = true
+}
+
+output "tunnel_raspi_4b_01_token" {
+  value     = cloudflare_zero_trust_tunnel_cloudflared.raspi_4b_01.tunnel_token
+  sensitive = true
+}
+
+output "tunnel_raspi_4b_01_cname" {
+  value = cloudflare_zero_trust_tunnel_cloudflared.raspi_4b_01.cname
+}
+
 
 #
 # CNAME

--- a/zero_trust/tunnel.tf
+++ b/zero_trust/tunnel.tf
@@ -8,3 +8,32 @@ resource "cloudflare_tunnel" "eq12_01" {
 resource "random_password" "eq12_01_tunnel_secret" {
   length = 64
 }
+
+#
+# raspi-4b-01
+#
+resource "cloudflare_zero_trust_tunnel_cloudflared" "raspi_4b_01" {
+  account_id = var.cloudflare_account_id
+  name       = "raspi_4b_01"
+  secret     = base64encode(random_password.raspi_4b_01_tunnel_secret.result)
+  config_src = "cloudflare"
+}
+
+resource "random_password" "raspi_4b_01_tunnel_secret" {
+  length = 64
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "raspi_4b_01" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.raspi_4b_01.id
+
+  config {
+    ingress_rule {
+      hostname = cloudflare_zero_trust_access_application.raspi_4b_01_ssh.domain
+      service  = "ssh://127.0.0.1:9922"
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}

--- a/zero_trust/variables.tf
+++ b/zero_trust/variables.tf
@@ -30,6 +30,11 @@ variable "app_eq12_01_ssh_domain" {
   description = "Access Application の EQ12 の SSH 接続のドメイン"
 }
 
+variable "app_raspi_4b_01_ssh_domain" {
+  type        = string
+  description = "Access Application の raspi-4b-01 の SSH 接続のドメイン"
+}
+
 variable "tunnel_home_assistant_domain" {
   type        = string
   description = "Home Assistant のドメイン"


### PR DESCRIPTION
raspi-4b-01のSSH接続を復活させた。

殆ど https://github.com/hiroxto/infrastructure/pull/83 の打ち消し。
非推奨のリソースを使っている箇所があったので，リバートはせずに新規で作成した。