### PR TITLE
Cloudflare Zero Trustリソースのdeprecated対応 その2

### DIFF
--- a/zero_trust/access_application.tf
+++ b/zero_trust/access_application.tf
@@ -8,7 +8,7 @@ resource "cloudflare_zero_trust_access_application" "eq12_01_ssh" {
   type                 = "ssh"
   app_launcher_visible = false
   allowed_idps = [
-    cloudflare_access_identity_provider.google.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
   ]
   policies = [
     cloudflare_zero_trust_access_policy.admin.id
@@ -25,7 +25,7 @@ resource "cloudflare_zero_trust_access_application" "raspi_4b_01_ssh" {
   type                 = "ssh"
   app_launcher_visible = false
   allowed_idps = [
-    cloudflare_access_identity_provider.google.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
   ]
   policies = [
     cloudflare_zero_trust_access_policy.admin.id
@@ -42,7 +42,7 @@ resource "cloudflare_zero_trust_access_application" "epgstation" {
   type                 = "self_hosted"
   app_launcher_visible = true
   allowed_idps = [
-    cloudflare_access_identity_provider.google.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
   ]
   policies = [
     cloudflare_zero_trust_access_policy.admin.id,

--- a/zero_trust/access_identity_provider.tf
+++ b/zero_trust/access_identity_provider.tf
@@ -1,10 +1,10 @@
-resource "cloudflare_access_identity_provider" "onetimepin" {
+resource "cloudflare_zero_trust_access_identity_provider" "onetimepin" {
   account_id = var.cloudflare_account_id
   name       = "One-time PIN"
   type       = "onetimepin"
 }
 
-resource "cloudflare_access_identity_provider" "google" {
+resource "cloudflare_zero_trust_access_identity_provider" "google" {
   account_id = var.cloudflare_account_id
   name       = "Google"
   type       = "google"

--- a/zero_trust/outputs.tf
+++ b/zero_trust/outputs.tf
@@ -2,21 +2,21 @@
 # eq12_01
 #
 output "tunnel_eq12_01_id" {
-  value = cloudflare_tunnel.eq12_01.id
+  value = cloudflare_zero_trust_tunnel_cloudflared.eq12_01.id
 }
 
 output "tunnel_eq12_01_secret" {
-  value     = cloudflare_tunnel.eq12_01.secret
+  value     = cloudflare_zero_trust_tunnel_cloudflared.eq12_01.secret
   sensitive = true
 }
 
 output "tunnel_eq12_01_token" {
-  value     = cloudflare_tunnel.eq12_01.tunnel_token
+  value     = cloudflare_zero_trust_tunnel_cloudflared.eq12_01.tunnel_token
   sensitive = true
 }
 
 output "tunnel_eq12_01_cname" {
-  value = cloudflare_tunnel.eq12_01.cname
+  value = cloudflare_zero_trust_tunnel_cloudflared.eq12_01.cname
 }
 
 #
@@ -45,7 +45,7 @@ output "tunnel_raspi_4b_01_cname" {
 # CNAME
 #
 output "tunnel_epgstation_cname" {
-  value = cloudflare_tunnel.eq12_01.cname
+  value = cloudflare_zero_trust_tunnel_cloudflared.eq12_01.cname
 }
 
 #

--- a/zero_trust/tunnel.tf
+++ b/zero_trust/tunnel.tf
@@ -1,7 +1,7 @@
 #
 # eq12-01
 #
-resource "cloudflare_tunnel" "eq12_01" {
+resource "cloudflare_zero_trust_tunnel_cloudflared" "eq12_01" {
   account_id = var.cloudflare_account_id
   name       = "eq12_01"
   secret     = base64encode(random_password.eq12_01_tunnel_secret.result)
@@ -12,9 +12,9 @@ resource "random_password" "eq12_01_tunnel_secret" {
   length = 64
 }
 
-resource "cloudflare_tunnel_config" "eq12_01" {
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "eq12_01" {
   account_id = var.cloudflare_account_id
-  tunnel_id  = cloudflare_tunnel.eq12_01.id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.eq12_01.id
 
   config {
     ingress_rule {


### PR DESCRIPTION
https://github.com/hiroxto/infrastructure/pull/137 で移行しなかったリソースを移行した。

移行対象
- cloudflare_tunnel → cloudflare_zero_trust_tunnel_cloudflared
  - importしたが，secretとconfig_srcがインポートされなかったので手動でtfstateを編集した
- cloudflare_tunnel_config → cloudflare_zero_trust_tunnel_cloudflared_config
  - importして差分なし
- cloudflare_access_identity_provider → cloudflare_zero_trust_access_identity_provider
  - importしたがgoogleのclient_idとclient_secretに差分が出てしまう
  - 一旦これでapplyしてみる

Check
- [x] 上記リソースのWarning: Deprecated Resourceが消えている
- [x] `cloudflare_zero_trust_access_identity_provider.google`以外のリソースでplanに差分なし